### PR TITLE
Remove CallbackContext's _depth property

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -171,9 +171,6 @@ class CallbackContext:
         - estimator_name : str
             The name of the estimator.
 
-        - depth : int
-            The depth of the task in the task tree.
-
         - prev_estimator_name : str or None
             The estimator name of the parent task this task was merged with. None if it
             was not merged with another context.
@@ -193,18 +190,12 @@ class CallbackContext:
             "task_id": self._task_id,
             "max_subtasks": self._max_subtasks,
             "estimator_name": self._estimator_name,
-            "depth": self._depth,
             "prev_estimator_name": self._prev_estimator_name,
             "prev_task_name": self._prev_task_name,
             "parent_task_info": None
             if self._parent is None
             else self._parent.task_info,
         }
-
-    @property
-    def _depth(self):
-        """The depth of this task in the task tree."""
-        return 0 if self._parent is None else self._parent._depth + 1
 
     def __iter__(self):
         """Pre-order depth-first traversal of the task tree."""

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -197,8 +197,9 @@ class RichTask:
         """Return a formatted description for the task."""
         colors = ["bright_magenta", "cyan", "dark_orange"]
 
-        indent = f"{'  ' * (task_info['depth'])}"
-        style = f"[{colors[(task_info['depth']) % len(colors)]}]"
+        depth = len(_get_task_info_path(task_info)) - 1
+        indent = f"{'  ' * depth}"
+        style = f"[{colors[(depth) % len(colors)]}]"
 
         task_desc = f"{task_info['estimator_name']} - {task_info['task_name']}"
         id_mark = (

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from sklearn.callback._callback_context import CallbackContext
+from sklearn.callback._progressbar import _get_task_info_path
 from sklearn.callback.tests._utils import (
     Estimator,
     MetaEstimator,
@@ -94,18 +95,18 @@ def test_task_tree():
     root = _make_task_tree(n_children=3, n_grandchildren=5)
 
     assert root._parent is None
-    assert root._depth == 0
+    assert len(_get_task_info_path(root.task_info)) == 1
     assert len(root._children_map) == 3
 
     for child in root._children_map.values():
         assert child._parent is root
-        assert child._depth == 1
+        assert len(_get_task_info_path(child.task_info)) == 2
         assert len(child._children_map) == 5
         assert root._max_subtasks == 3
 
         for grandchild in child._children_map.values():
             assert grandchild._parent is child
-            assert grandchild._depth == 2
+            assert len(_get_task_info_path(grandchild.task_info)) == 3
             assert len(grandchild._children_map) == 0
             assert child._max_subtasks == 5
 


### PR DESCRIPTION
Remove the `CallbackContext`'s `_depth` property, as it can easily be obtained as `len(_get_task_info_path(self.task_info))`.