### PR TITLE
Remove task_info and use directly CallbackContext

### DIFF
--- a/sklearn/callback/_base.py
+++ b/sklearn/callback/_base.py
@@ -17,7 +17,7 @@ class Callback(Protocol):
             The estimator calling this callback hook.
         """
 
-    def _on_fit_task_end(self, estimator, callback_ctx, **kwargs):
+    def _on_fit_task_end(self, estimator, context, **kwargs):
         """Method called at the end of each task of the estimator.
 
         Parameters
@@ -26,8 +26,8 @@ class Callback(Protocol):
             The estimator calling this callback hook. It might differ from the estimator
             passed to the `_on_fit_begin` method for auto-propagated callbacks.
 
-        callback_ctx : `sklearn.callback.CallbackContext`
-            Callback context of the corresponding task.
+        context : `sklearn.callback.CallbackContext` instance
+            Context of the corresponding task.
 
         **kwargs : dict
             Information about the state of the fitting process at this task. Possible
@@ -61,7 +61,7 @@ class Callback(Protocol):
             Whether or not to stop the current level of iterations at this task.
         """
 
-    def _on_fit_end(self, estimator, callback_ctx):
+    def _on_fit_end(self, estimator, context):
         """Method called at the end of the fit method of the estimator.
 
         Parameters
@@ -69,10 +69,10 @@ class Callback(Protocol):
         estimator : estimator instance
             The estimator calling this callback hook.
 
-        callback_ctx : `sklearn.callback.CallbackContext`
-            Callback context of the corresponding task. This is usually the
-            root of the task tree of the estimator but it can be an intermediate node
-            if the estimator is a sub-estimator of a meta-estimator.
+        context : `sklearn.callback.CallbackContext`
+            Context of the corresponding task. This is usually the root context of the
+            estimator but it can be an intermediate context if the estimator is a
+            sub-estimator of a meta-estimator.
         """
 
 

--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -62,9 +62,34 @@ class CallbackContext:
     Instances of this class should be created using the `init_callback_context` method
     of its estimator or the `subcontext` method of this class.
 
-    To keep track of the position of a task in the task tree within the callbacks,
-    a dictionary containing all relevant information about the task is provided to the
-    callback hooks. It's accessible through the `task_info` property of this class.
+    These contexts are passed to the callback hooks to be able to keep track of the
+    position of a task in the task tree within the callbacks.
+
+    Attributes
+    ----------
+    - task_name : str
+        The name of the task this context is responsible for.
+
+    - task_id : int
+        The identifier of the task this context is responsible for.
+
+    - max_subtasks : int or None
+        The maximum number of children tasks for this task. 0 means it's a leaf.
+        None means the maximum number of subtasks is not known in advance.
+
+    - estimator_name : str
+        The name of the estimator.
+
+    - prev_estimator_name : str or None
+        The estimator name of the parent task this task was merged with. None if it
+        was not merged with another context.
+
+    - prev_task_name : str or None
+        The task name of the parent task this task was merged with. None if it
+        was not merged with another context.
+
+    - parent : CallbackContext or None
+        The parent context of this context. None if this context is the root.
     """
 
     @classmethod
@@ -342,23 +367,22 @@ class CallbackContext:
         return self
 
 
-def get_task_info_path(task_info):
-    """Helper function to get the path of task info from this task to the root task.
+def get_context_path(context):
+    """Helper function to get the path from the root context down to a given context.
 
     Parameters
     ----------
-    task_info : dict
-        The dictionary representation of a task as returned by
-        `CallbackContext.task_info`.
+    context : `CallbackContext` instance
+        The context to get the path to.
 
     Returns
     -------
     list of dict
-        The list of dictionary representations of the ancestors (itself included) of the
-        given task.
+        The list of the ancestors (itself included) of the given context. The list is
+        ordered from the root context to the given context.
     """
     return (
-        [task_info]
-        if task_info["parent_task_info"] is None
-        else get_task_info_path(task_info["parent_task_info"]) + [task_info]
+        [context]
+        if context.parent is None
+        else get_context_path(context.parent) + [context]
     )

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -17,7 +17,7 @@ class TestingCallback:
     def _on_fit_end(self):
         pass
 
-    def _on_fit_task_end(self, estimator, task_info, **kwargs):
+    def _on_fit_task_end(self, estimator, context, **kwargs):
         pass
 
 
@@ -33,7 +33,7 @@ class NotValidCallback:
     def _on_fit_begin(self, estimator):
         pass  # pragma: no cover
 
-    def _on_fit_task_end(self, estimator, task_info, **kwargs):
+    def _on_fit_task_end(self, estimator, context, **kwargs):
         pass  # pragma: no cover
 
 

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -4,7 +4,7 @@
 import numpy as np
 import pytest
 
-from sklearn.callback._callback_context import CallbackContext, get_task_info_path
+from sklearn.callback._callback_context import CallbackContext, get_context_path
 from sklearn.callback.tests._utils import (
     Estimator,
     MetaEstimator,
@@ -93,19 +93,19 @@ def test_task_tree():
     """Check that the task tree is correctly built."""
     root = _make_task_tree(n_children=3, n_grandchildren=5)
 
-    assert root._parent is None
-    assert len(get_task_info_path(root.task_info)) == 1
+    assert root.parent is None
+    assert len(get_context_path(root)) == 1
     assert len(root._children_map) == 3
 
     for child in root._children_map.values():
-        assert child._parent is root
-        assert len(get_task_info_path(child.task_info)) == 2
+        assert child.parent is root
+        assert len(get_context_path(child)) == 2
         assert len(child._children_map) == 5
         assert root.max_subtasks == 3
 
         for grandchild in child._children_map.values():
-            assert grandchild._parent is child
-            assert len(get_task_info_path(grandchild.task_info)) == 3
+            assert grandchild.parent is child
+            assert len(get_context_path(grandchild)) == 3
             assert len(grandchild._children_map) == 0
             assert child.max_subtasks == 5
 


### PR DESCRIPTION
Feed directly the CallbackContext object to `on_fit_task_end` and `on_fit_end` instead of the task_info dictionary representation. 