### PR TITLE
Dynamically wrap fit in the CallbackSupportMixin to initialize the callback context

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -123,23 +123,13 @@ class CallbackContext:
     """
 
     @classmethod
-    def _from_estimator(cls, estimator, *, task_name, task_id, max_subtasks=None):
+    def _from_estimator(cls, estimator):
         """Private constructor to create a root context.
 
         Parameters
         ----------
         estimator : estimator instance
             The estimator this context is responsible for.
-
-        task_name : str
-            The name of the task this context is responsible for.
-
-        task_id : int
-            The id of the task this context is responsible for.
-
-        max_subtasks : int or None, default=None
-            The maximum number of subtasks of this task. 0 means it's a leaf.
-            None means the maximum number of subtasks is not known in advance.
         """
         new_ctx = cls.__new__(cls)
 
@@ -147,11 +137,11 @@ class CallbackContext:
         # because the estimator already holds a reference to the context.
         new_ctx._callbacks = getattr(estimator, "_skl_callbacks", [])
         new_ctx.estimator_name = estimator.__class__.__name__
-        new_ctx.task_name = task_name
-        new_ctx.task_id = task_id
+        new_ctx.task_name = "fit"
+        new_ctx.task_id = 0
         new_ctx.parent = None
         new_ctx._children_map = {}
-        new_ctx.max_subtasks = max_subtasks
+        new_ctx.max_subtasks = None
         new_ctx.prev_estimator_name = None
         new_ctx.prev_task_name = None
 
@@ -206,6 +196,26 @@ class CallbackContext:
         parent_context._add_child(new_ctx)
 
         return new_ctx
+
+    def set_task_info(self, task_name, task_id, max_subtasks=None):
+        """Setter for the attributes relative to the task information.
+
+        Parameters
+        ----------
+        task_name : str
+            The name of the task this context is responsible for.
+
+        task_id : int
+            The id of the task this context is responsible for.
+
+        max_subtasks : int or None, default=None
+            The maximum number of tasks that can be children of the task this context is
+            responsible for. 0 means it's a leaf. None means the maximum number of
+            subtasks is not known in advance.
+        """
+        self.task_name = task_name
+        self.task_id = task_id
+        self.max_subtasks = max_subtasks
 
     def __iter__(self):
         """Pre-order depth-first traversal of the task tree."""

--- a/sklearn/callback/_mixin.py
+++ b/sklearn/callback/_mixin.py
@@ -10,6 +10,11 @@ from sklearn.callback._callback_context import CallbackContext
 class CallbackSupportMixin:
     """Mixin class to add callback support to an estimator."""
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if hasattr(cls, "fit"):
+            cls.fit = _fit_callback(cls.fit)
+
     def set_callbacks(self, callbacks):
         """Set callbacks for the estimator.
 
@@ -39,12 +44,6 @@ def _fit_callback(fit_method):
 
     @functools.wraps(fit_method)
     def wrapper(estimator, *args, **kwargs):
-        if not isinstance(estimator, CallbackSupportMixin):
-            raise ValueError(
-                f"Estimator {estimator.__class__.__name__} does not support callbacks,"
-                " as it does not inherit from CallbackSupportMixin."
-            )
-
         estimator._callback_fit_ctx = CallbackContext._from_estimator(estimator)
 
         try:

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -5,7 +5,6 @@ import time
 
 from sklearn.base import BaseEstimator, _fit_context, clone
 from sklearn.callback import CallbackSupportMixin
-from sklearn.callback._mixin import _fit_callback
 from sklearn.utils.parallel import Parallel, delayed
 
 
@@ -50,7 +49,6 @@ class Estimator(CallbackSupportMixin, BaseEstimator):
         self.max_iter = max_iter
         self.computation_intensity = computation_intensity
 
-    @_fit_callback
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X=None, y=None, X_val=None, y_val=None):
         self._callback_fit_ctx.set_task_info(
@@ -84,7 +82,6 @@ class WhileEstimator(CallbackSupportMixin, BaseEstimator):
     def __init__(self, computation_intensity=0.001):
         self.computation_intensity = computation_intensity
 
-    @_fit_callback
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X=None, y=None, X_val=None, y_val=None):
         self._callback_fit_ctx.set_task_info(
@@ -129,7 +126,6 @@ class MetaEstimator(CallbackSupportMixin, BaseEstimator):
         self.n_jobs = n_jobs
         self.prefer = prefer
 
-    @_fit_callback
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         self._callback_fit_ctx.set_task_info(
@@ -172,9 +168,3 @@ def _func(meta_estimator, inner_estimator, X, y, *, callback_ctx):
         estimator=meta_estimator,
         data={"X_train": X, "y_train": y},
     )
-
-
-class EstimatorWithoutCallbackMixin(BaseEstimator):
-    @_fit_callback
-    def fit(self, X=None, y=None):
-        pass

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -172,3 +172,9 @@ def _func(meta_estimator, inner_estimator, X, y, *, callback_ctx):
         estimator=meta_estimator,
         data={"X_train": X, "y_train": y},
     )
+
+
+class EstimatorWithoutCallbackMixin(BaseEstimator):
+    @_fit_callback
+    def fit(self, X=None, y=None):
+        pass

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -22,7 +22,7 @@ def test_propagate_callbacks():
     metaestimator = MetaEstimator(estimator)
     metaestimator.set_callbacks([not_propagated_callback, propagated_callback])
 
-    callback_ctx = metaestimator.__skl_init_callback_context__()
+    callback_ctx = CallbackContext._from_estimator(metaestimator)
     callback_ctx.propagate_callbacks(estimator)
 
     assert hasattr(estimator, "_parent_callback_ctx")
@@ -35,7 +35,7 @@ def test_propagate_callback_no_callback():
     estimator = Estimator()
     metaestimator = MetaEstimator(estimator)
 
-    callback_ctx = metaestimator.__skl_init_callback_context__()
+    callback_ctx = CallbackContext._from_estimator(metaestimator)
     assert len(callback_ctx._callbacks) == 0
 
     callback_ctx.propagate_callbacks(estimator)
@@ -62,16 +62,16 @@ def test_auto_propagated_callbacks():
 def _make_task_tree(n_children, n_grandchildren):
     """Helper function to create a tree of tasks with a context for each task."""
     estimator = Estimator()
-    root = CallbackContext._from_estimator(
-        estimator,
+    root = CallbackContext._from_estimator(estimator)
+    root.set_task_info(
         task_name="root task",
         task_id=0,
         max_subtasks=n_children,
     )
 
     for i in range(n_children):
-        child = CallbackContext._from_estimator(
-            estimator,
+        child = CallbackContext._from_estimator(estimator)
+        child.set_task_info(
             task_name="child task",
             task_id=i,
             max_subtasks=n_grandchildren,
@@ -79,8 +79,8 @@ def _make_task_tree(n_children, n_grandchildren):
         root._add_child(child)
 
         for j in range(n_grandchildren):
-            grandchild = CallbackContext._from_estimator(
-                estimator,
+            grandchild = CallbackContext._from_estimator(estimator)
+            grandchild.set_task_info(
                 task_name="grandchild task",
                 task_id=j,
             )
@@ -122,57 +122,51 @@ def test_task_tree():
 def test_add_child():
     """Sanity check for the `_add_child` method."""
     estimator = Estimator()
-    root = CallbackContext._from_estimator(
-        estimator, task_name="root task", task_id=0, max_subtasks=2
-    )
+    root = CallbackContext._from_estimator(estimator)
+    root.set_task_info(task_name="root task", task_id=0, max_subtasks=2)
 
-    root._add_child(
-        CallbackContext._from_estimator(estimator, task_name="child task", task_id=0)
-    )
+    first_child = CallbackContext._from_estimator(estimator)
+    first_child.set_task_info(task_name="child task", task_id=0)
+
+    root._add_child(first_child)
     assert root.max_subtasks == 2
     assert len(root._children_map) == 1
 
+    second_child = CallbackContext._from_estimator(estimator)
+    second_child.set_task_info(task_name="child task", task_id=0)
     # root already has a child with id 0
     with pytest.raises(
         ValueError, match=r"Callback context .* already has a child with task_id=0"
     ):
-        root._add_child(
-            CallbackContext._from_estimator(
-                estimator, task_name="child task", task_id=0
-            )
-        )
+        root._add_child(second_child)
 
-    root._add_child(
-        CallbackContext._from_estimator(estimator, task_name="child task", task_id=1)
-    )
+    second_child.set_task_info(task_name="child task", task_id=1)
+    root._add_child(second_child)
     assert len(root._children_map) == 2
 
+    third_child = CallbackContext._from_estimator(estimator)
+    third_child.set_task_info(task_name="child task", task_id=2)
     # root can have at most 2 children
     with pytest.raises(ValueError, match=r"Cannot add child to callback context"):
-        root._add_child(
-            CallbackContext._from_estimator(
-                estimator, task_name="child task", task_id=2
-            )
-        )
+        root._add_child(third_child)
 
 
 def test_merge_with():
     """Sanity check for the `_merge_with` method."""
     estimator = Estimator()
     meta_estimator = MetaEstimator(estimator)
-    outer_root = CallbackContext._from_estimator(
-        meta_estimator, task_name="root", task_id=0, max_subtasks=2
-    )
+    outer_root = CallbackContext._from_estimator(meta_estimator)
+    outer_root.set_task_info(task_name="root", task_id=0, max_subtasks=2)
 
     # Add a child task within the same estimator
-    outer_child = CallbackContext._from_estimator(
-        meta_estimator, task_name="child", task_id="id", max_subtasks=1
-    )
+    outer_child = CallbackContext._from_estimator(meta_estimator)
+    outer_child.set_task_info(task_name="child", task_id="id", max_subtasks=1)
     outer_root._add_child(outer_child)
 
     # The root task of the inner estimator is merged with (and effectively replaces)
     # a leaf of the outer estimator because they correspond to the same formal task.
-    inner_root = CallbackContext._from_estimator(estimator, task_name="root", task_id=0)
+    inner_root = CallbackContext._from_estimator(estimator)
+    inner_root.set_task_info(task_name="root", task_id=0)
     inner_root._merge_with(outer_child)
 
     assert inner_root.parent is outer_root

--- a/sklearn/callback/tests/test_mixin.py
+++ b/sklearn/callback/tests/test_mixin.py
@@ -39,12 +39,3 @@ def test_set_callbacks_error(callbacks):
 
     with pytest.raises(TypeError, match="callbacks must follow the Callback protocol."):
         estimator.set_callbacks(callbacks)
-
-
-def test_init_callback_context():
-    """Sanity check for the `__skl_init_callback_context__` method."""
-    estimator = Estimator()
-    callback_ctx = estimator.__skl_init_callback_context__()
-
-    assert hasattr(estimator, "_callback_fit_ctx")
-    assert hasattr(callback_ctx, "_callbacks")

--- a/sklearn/callback/tests/test_mixin.py
+++ b/sklearn/callback/tests/test_mixin.py
@@ -39,3 +39,10 @@ def test_set_callbacks_error(callbacks):
 
     with pytest.raises(TypeError, match="callbacks must follow the Callback protocol."):
         estimator.set_callbacks(callbacks)
+
+
+def test_callback_removed_after_fit():
+    """Test that the _callback_fit_ctx attribute gets removed after fit."""
+    estimator = Estimator()
+    estimator.fit()
+    assert not hasattr(estimator, "_callback_fit_ctx")

--- a/sklearn/callback/tests/test_mixin.py
+++ b/sklearn/callback/tests/test_mixin.py
@@ -5,6 +5,7 @@ import pytest
 
 from sklearn.callback.tests._utils import (
     Estimator,
+    EstimatorWithoutCallbackMixin,
     NotValidCallback,
     TestingAutoPropagatedCallback,
     TestingCallback,
@@ -46,3 +47,15 @@ def test_callback_removed_after_fit():
     estimator = Estimator()
     estimator.fit()
     assert not hasattr(estimator, "_callback_fit_ctx")
+
+
+def test_decorator_error():
+    """Test the error raised by _fit_callback if the estimator does not inherit from
+    CallbackSupportMixin"""
+    estimator = EstimatorWithoutCallbackMixin()
+    with pytest.raises(
+        ValueError,
+        match="does not support callbacks, as it does not inherit from"
+        " CallbackSupportMixin.",
+    ):
+        estimator.fit()

--- a/sklearn/callback/tests/test_mixin.py
+++ b/sklearn/callback/tests/test_mixin.py
@@ -5,7 +5,6 @@ import pytest
 
 from sklearn.callback.tests._utils import (
     Estimator,
-    EstimatorWithoutCallbackMixin,
     NotValidCallback,
     TestingAutoPropagatedCallback,
     TestingCallback,
@@ -47,15 +46,3 @@ def test_callback_removed_after_fit():
     estimator = Estimator()
     estimator.fit()
     assert not hasattr(estimator, "_callback_fit_ctx")
-
-
-def test_decorator_error():
-    """Test the error raised by _fit_callback if the estimator does not inherit from
-    CallbackSupportMixin"""
-    estimator = EstimatorWithoutCallbackMixin()
-    with pytest.raises(
-        ValueError,
-        match="does not support callbacks, as it does not inherit from"
-        " CallbackSupportMixin.",
-    ):
-        estimator.fit()


### PR DESCRIPTION
The callback context relative to the `fit` is intialized in a decorator around `fit`, and the `fit` function is dynamically decorated through `__init_subclass__` in the `CallbackSupportMixin` class. 