### PR TITLE
Fix regex check in progressbar

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -238,7 +238,6 @@ class CallbackContext:
         # meta-estimator's leaf context
         self.parent = other_context.parent
         self.task_id = other_context.task_id
-        self.max_subtasks = other_context.max_subtasks
         other_context.parent._children_map[self.task_id] = self
 
         # Keep information about the context it was merged with

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -203,9 +203,14 @@ class RichTask:
         style = f"[{colors[(self.depth) % len(colors)]}]"
 
         task_desc = f"{context.estimator_name} - {context.task_name}"
-        id_mark = f" #{context.task_id}" if context.parent is not None else ""
+        id_mark = (
+            f" #{context.task_id}"
+            if context.parent is not None and context.prev_estimator_name is None
+            else ""
+        )
         prev_task_desc = (
-            f"{context.prev_estimator_name} - {context.prev_task_name} | "
+            f"{context.prev_estimator_name} - {context.prev_task_name}"
+            f" #{context.task_id} | "
             if context.prev_estimator_name is not None
             else ""
         )

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -203,11 +203,7 @@ class RichTask:
         style = f"[{colors[(self.depth) % len(colors)]}]"
 
         task_desc = f"{context.estimator_name} - {context.task_name}"
-        id_mark = (
-            f" #{context.task_id}"
-            if context.parent is not None and context.prev_estimator_name is None
-            else ""
-        )
+        id_mark = f" #{context.task_id}" if context.parent is not None else ""
         prev_task_desc = (
             f"{context.prev_estimator_name} - {context.prev_task_name}"
             f" #{context.task_id} | "

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -205,8 +205,7 @@ class RichTask:
         task_desc = f"{context.estimator_name} - {context.task_name}"
         id_mark = f" #{context.task_id}" if context.parent is not None else ""
         prev_task_desc = (
-            f"{context.prev_estimator_name} - {context.prev_task_name}"
-            f" #{context.task_id} | "
+            f"{context.prev_estimator_name} - {context.prev_task_name} | "
             if context.prev_estimator_name is not None
             else ""
         )

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -39,7 +39,7 @@ def test_progressbar(n_jobs, prefer, InnerEstimator, max_estimator_depth, capsys
     if max_estimator_depth is None or max_estimator_depth > 1:
         for i in range(n_inner):
             assert re.search(
-                rf"MetaEstimator - inner #{i} | {est.__class__.__name__} - fit",
+                rf"MetaEstimator - inner \| {est.__class__.__name__} - fit #{i}",
                 captured.out,
             )
 

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -39,7 +39,7 @@ def test_progressbar(n_jobs, prefer, InnerEstimator, max_estimator_depth, capsys
     if max_estimator_depth is None or max_estimator_depth > 1:
         for i in range(n_inner):
             assert re.search(
-                rf"MetaEstimator - inner #{i} \| {est.__class__.__name__} - fit #{i}",
+                rf"MetaEstimator - inner \| {est.__class__.__name__} - fit #{i}",
                 captured.out,
             )
 

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -39,7 +39,7 @@ def test_progressbar(n_jobs, prefer, InnerEstimator, max_estimator_depth, capsys
     if max_estimator_depth is None or max_estimator_depth > 1:
         for i in range(n_inner):
             assert re.search(
-                rf"MetaEstimator - inner #{i} \| {est.__class__.__name__} - fit",
+                rf"MetaEstimator - inner #{i} \| {est.__class__.__name__} - fit #{i}",
                 captured.out,
             )
 

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -39,7 +39,7 @@ def test_progressbar(n_jobs, prefer, InnerEstimator, max_estimator_depth, capsys
     if max_estimator_depth is None or max_estimator_depth > 1:
         for i in range(n_inner):
             assert re.search(
-                rf"MetaEstimator - inner \| {est.__class__.__name__} - fit #{i}",
+                rf"MetaEstimator - inner #{i} \| {est.__class__.__name__} - fit",
                 captured.out,
             )
 


### PR DESCRIPTION
The pipe symbol means "or" in regex, so it must be escaped. Also the `#{i}` is currently after "fit" and not after "inner".